### PR TITLE
expose csrf token without templating

### DIFF
--- a/src/flea/csrf.lua
+++ b/src/flea/csrf.lua
@@ -4,9 +4,15 @@ local time = require( "flea.time" )
 
 local _M = { }
 
-function _M.token( request, html )
+function _M.token_raw( request )
 	local token = request.cookies.csrf or arc4.buf( 16 ):tohex()
 	request:set_cookie( "csrf", token, time.hours( 2 ), { path = "/" } )
+
+	return token
+end
+
+function _M.token( request, html )
+	local token = _M.token_raw( request )
 
 	return html.input( { name = "csrf", type = "hidden", value = token } )
 end


### PR DESCRIPTION
I am using an external templating system, but I still would like to take advantage of the csrf token validation. This is the simplest diff that allows that without breaking the api. I think the most appropriate change would be to move csrf.token() into request.lua, and leave the html generation inside csrf.lua to hide the csrf internals. I can also write this diff if you would prefer this route.
