### PR TITLE
Fix request.headers

### DIFF
--- a/src/flea/request.lua
+++ b/src/flea/request.lua
@@ -145,10 +145,12 @@ local function request_add_tables( request )
 				return nil
 			end
 
-			local header = fcgi.getenv( "HTTP_" .. header:upper():gsub( "%-", "_" ) )
+			local header = fcgi.getenv( "HTTP_" .. key:upper():gsub( "%-", "_" ) )
 
 			headers_seen[ key ] = true
 			self[ key ] = header
+			
+			return header
 		end,
 	}
 


### PR DESCRIPTION
Variable name typo, and return the fetched header so we don't need to double query the table.
