### PR TITLE
Allow any fcgi variable to be queried

### DIFF
--- a/src/flea/request.lua
+++ b/src/flea/request.lua
@@ -145,7 +145,7 @@ local function request_add_tables( request )
 				return nil
 			end
 
-			local header = fcgi.getenv( "HTTP_" .. header:upper():gsub( "%-", "_" ) )
+			local header = fcgi.getenv( header:upper():gsub( "%-", "_" ) )
 
 			headers_seen[ key ] = true
 			self[ key ] = header


### PR DESCRIPTION
Allow all fcgi variables to be queried, not just the HTTP_ ones.
