### PR TITLE
Add request:log() function

### DIFF
--- a/src/flea/request.lua
+++ b/src/flea/request.lua
@@ -82,6 +82,13 @@ local function request_add_methods( request )
 
 		self.status = { 404, "Not Found" }
 	end
+	
+	request.log = function( self, level, message )
+		print( level .. ": " ..
+			"IP:" .. self.headers.REMOTE_ADDR ..
+			" agent:\"" .. self.headers.HTTP_USER_AGENT .. "\" " ..
+			message )
+	end
 end
 
 local function parse_query( query )


### PR DESCRIPTION
This allows some basic logging to stdio. Takes a level string (WARN, ERROR, INFO) and the message to print, and gives a somewhat useful output. I'm not sure I'm happy with the format, it should probably conform to NGINX or apache access logs style. Logging to a file vs blindly printing may also be useful.
